### PR TITLE
Porting Tresca applications to new architecture

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -37,3 +37,9 @@ option(BUILD_APP_HELMHOLTZ "Build Helmholtz applications" ON)
 if (BUILD_APP_HELMHOLTZ)
     add_subdirectory(helmholtz)
 endif()
+
+option(BUILD_APP_TRESCA "Build Tresca applications" ON)
+if (BUILD_APP_TRESCA)
+    add_subdirectory(tresca)
+endif()
+

--- a/apps/tresca/CMakeLists.txt
+++ b/apps/tresca/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(LINK_LIBS diskpp)
+
+add_executable(tresca src/tresca.cpp)
+target_link_libraries(tresca ${LINK_LIBS})
+install(TARGETS tresca RUNTIME DESTINATION bin)
+
+add_executable(tresca_test src/tresca_test.cpp)
+target_link_libraries(tresca_test ${LINK_LIBS})
+install(TARGETS tresca_test RUNTIME DESTINATION bin)
+
+install(DIRECTORY share/ DESTINATION share)
+
+

--- a/apps/tresca/src/NewtonSolver/tresca_elementary_computation.hpp
+++ b/apps/tresca/src/NewtonSolver/tresca_elementary_computation.hpp
@@ -27,11 +27,9 @@
 
 #include <cassert>
 
-#include "bases/bases.hpp"
-#include "common/eigen.hpp"
-#include "mechanics/behaviors/maths_tensor.hpp"
-#include "methods/hho"
-#include "quadratures/quadratures.hpp"
+#include "diskpp/common/eigen.hpp"
+#include "diskpp/mechanics/behaviors/maths_tensor.hpp"
+#include "diskpp/methods/hho"
 
 #include "timecounter.h"
 

--- a/apps/tresca/src/tresca.cpp
+++ b/apps/tresca/src/tresca.cpp
@@ -29,21 +29,18 @@
 #include <regex>
 #include <sstream>
 #include <unistd.h>
-
 #include <map>
-
-#include "Informations.hpp"
-#include "Parameters.hpp"
-#include "boundary_conditions/boundary_conditions.hpp"
-#include "loaders/loader.hpp"
-#include "mechanics/behaviors/laws/materialData.hpp"
-
-#include "timecounter.h"
-
 #define _USE_MATH_DEFINES
 #include <cmath>
 
-#include "tresca_solver.hpp"
+#include "src/Informations.hpp"
+#include "src/Parameters.hpp"
+#include "diskpp/boundary_conditions/boundary_conditions.hpp"
+#include "diskpp/loaders/loader.hpp"
+#include "diskpp/mechanics/behaviors/laws/materialData.hpp"
+
+#include "diskpp/common/timecounter.hpp"
+//#include "src/tresca_solver.hpp"
 
 template<template<typename, size_t, typename> class Mesh, typename T, typename Storage>
 void

--- a/apps/tresca/src/tresca_test.cpp
+++ b/apps/tresca/src/tresca_test.cpp
@@ -30,18 +30,15 @@
 #include <sstream>
 #include <unistd.h>
 
-#include "colormanip.h"
-
-#include "loaders/loader.hpp"
-
-#include "timecounter.h"
-
-#include "Informations.hpp"
-#include "Parameters.hpp"
-#include "boundary_conditions/boundary_conditions.hpp"
-#include "loaders/loader.hpp"
-#include "mechanics/behaviors/laws/materialData.hpp"
-#include "tresca_solver.hpp"
+#include "diskpp/common/colormanip.h"
+#include "diskpp/loaders/loader.hpp"
+#include "diskpp/common/timecounter.hpp"
+#include "diskpp/boundary_conditions/boundary_conditions.hpp"
+#include "diskpp/loaders/loader.hpp"
+#include "diskpp/mechanics/behaviors/laws/materialData.hpp"
+#include "src/tresca_solver.hpp"
+#include "src/Informations.hpp"
+#include "src/Parameters.hpp"
 
 struct error_type
 {


### PR DESCRIPTION
Porting Tresca applications. There are files missing, possibly from Newton Solver:
1. Informations.hpp
2. Parameters.hpp
See for example plasticity applications or finite strains applications.

